### PR TITLE
adding the ability to select between a stable main install or the cur…

### DIFF
--- a/hyprinstall.sh
+++ b/hyprinstall.sh
@@ -140,6 +140,34 @@ read -rp "$prompt [$default]: " ans
 init_logging
 log "INFO" "Starting hyprinstall-final. Log: $LOGFILE"
 
+# Branch selection for repo operations (supports UPDATE_BRANCH env var or .update-branch file)
+BRANCH="${UPDATE_BRANCH:-}"
+if [[ -f "$BASE_DIR/.update-branch" ]]; then
+  BRANCH="$(<$BASE_DIR/.update-branch)"
+fi
+if [[ -z "$BRANCH" && "$DRY_RUN" == "false" && -t 0 ]]; then
+  echo "Select branch to use for repo operations:"
+  echo "  1) main (end users)"
+  echo "  2) 0.3 (development)"
+  echo "  3) Enter branch name"
+  read -rp "Choice [1-3] (default 2): " _choice
+  case "$_choice" in
+    1) BRANCH="main" ;;
+    3) read -rp "Enter branch name: " BRANCH ;;
+    *) BRANCH="0.3" ;;
+  esac
+fi
+BRANCH="${BRANCH:-0.3}"
+log "INFO" "Using branch: $BRANCH"
+
+# If repo exists and is a git repo, attempt to check it out and update to the selected branch
+if git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  run_cmd "git -C \"$REPO_DIR\" fetch --prune origin"
+  # Best-effort checkout and pull; do not abort installer if these fail
+  run_cmd "git -C \"$REPO_DIR\" checkout \"$BRANCH\"" || true
+  run_cmd "git -C \"$REPO_DIR\" pull --ff-only origin \"$BRANCH\"" || true
+fi
+
 # Install core dependencies
 
 log "INFO" "Ensuring extra dependencies: ${EXTRA_DEPENDENCIES[*]}"

--- a/update.sh
+++ b/update.sh
@@ -3,12 +3,18 @@ set -euo pipefail
 
 # update.sh
 # Safely overwrite this repository with the remote branch state.
-# Usage: ./update.sh [remote]
-# - Defaults to remote 'origin'.
+# Usage: ./update.sh [remote] [branch]
+# - Defaults: remote 'origin', branch '0.3'.
 # Behavior:
-# 1. Creates a local backup branch named backup-before-update-<timestamp>.
-# 2. Fetches the remote and resets --hard to remote/current-branch.
-# 3. Removes untracked files (git clean -fdx).
+# - Fetches the remote and resets --hard to remote/branch.
+# - Removes untracked files (git clean -fdx).
+# Note: This script no longer creates local backup git branches.
+
+# Backup Hyprland monitor and workspace configs
+  echo "Moving Hyprland monitor and workspace configs to backup folder..."
+  mkdir -p "$HOME/.config/backup"
+  mv "$HOME/.config/hypr/monitors.conf" "$HOME/.config/backup/monitors.conf"
+  mv "$HOME/.config/hypr/workspaces.conf" "$HOME/.config/backup/workspaces.conf"
 
 repo_root="$(cd "$(dirname "$0")" && pwd)"
 cd "$repo_root"
@@ -19,15 +25,32 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
 fi
 
 remote="${1:-origin}"
-branch="$(git rev-parse --abbrev-ref HEAD)"
+# Branch selection priority: UPDATE_BRANCH env > $repo_root/.update-branch file > arg2 > interactive menu > default 0.3
+branch="${2:-}"
+if [[ -n "${UPDATE_BRANCH:-}" ]]; then
+  branch="$UPDATE_BRANCH"
+elif [[ -f "$repo_root/.update-branch" ]]; then
+  branch="$(<"$repo_root/.update-branch")"
+fi
+# If not provided, offer an interactive menu when running in a terminal
+if [[ -z "$branch" && -t 0 ]]; then
+  echo "Select branch to use:"
+  echo "  1) main (end users)"
+  echo "  2) 0.3 (development)"
+  echo "  3) Enter branch name"
+  read -rp "Choice [1-3] (default 2): " _choice
+  case "$_choice" in
+    1) branch="main" ;;
+    3) read -rp "Enter branch name: " branch ;;
+    *) branch="0.3" ;;
+  esac
+fi
+branch="${branch:-0.3}"
 timestamp="$(date +%Y%m%d-%H%M%S)"
-backup_branch="backup-before-update-$timestamp"
 
 echo "Repository: $repo_root"
-echo "Current branch: $branch"
+echo "Target branch: $branch"
 echo "Remote: $remote"
-echo "Creating backup branch: $backup_branch"
-git branch --force "$backup_branch" || git branch "$backup_branch"
 
 echo "Fetching from $remote..."
 git fetch --prune "$remote"
@@ -44,17 +67,10 @@ if git show-ref --verify --quiet "refs/remotes/$remote/$branch"; then
   git submodule update --init --recursive 2>/dev/null || true
 
   echo "Update complete. Local branch '$branch' now matches '$remote/$branch'."
-  echo "Backup of previous HEAD is on branch: $backup_branch"
 else
   echo "Error: remote branch '$remote/$branch' not found. Aborting." >&2
   exit 2
 fi
-# Backup Hyprland monitor and workspace configs
-  echo "Moving Hyprland monitor and workspace configs to backup folder..."
-  mkdir -p "$HOME/.config/backup"
-  mv "$HOME/.config/hypr/monitors.conf" "$HOME/.config/backup/monitors.conf"
-  mv "$HOME/.config/hypr/workspaces.conf" "$HOME/.config/backup/workspaces.conf"
-
   # By default, reapply symlinks and some dotfile tasks so the live system matches the repo.
   # Set SKIP_SYMLINKS=1 to skip this step.
   apply_symlinks() {


### PR DESCRIPTION
This will be 0.2.5 I am working on 0.3 currently which will include a few QOL additions.

Current main features of 0.2.5

- Ability to select branches: Main (stable), Dev (Will constant change and can possibly break exsisting installs)
- Full hyprupdate (This will allow you to change between Main and Dev but also allow you to update the dot files reliably)
- Updating hyprdots will not break monitor or workspaces config anymore yaaaay!
- Full support for changes to the windows rules
- Fully featured clipboard SUPER+C will open the clipboard allowing you to select previously copied items

I will continue to develop on the versioned branches. Warning however anyone who will be using this branch will be subjected to frequent breaks as this will be the most unstable one, please remain on main if you want a stable experience which will now remain stable.